### PR TITLE
Fix integration test

### DIFF
--- a/tests/Qdrant.Client.Tests/ApiKeyCertificateThumbprintTests.cs
+++ b/tests/Qdrant.Client.Tests/ApiKeyCertificateThumbprintTests.cs
@@ -82,8 +82,12 @@ public class ApiKeyCertificateThumbprintTests
 		var client = new QdrantGrpcClient(callInvoker);
 
 		var exception = Assert.Throws<RpcException>(() => client.Qdrant.HealthCheck(new HealthCheckRequest()));
+#if NETFRAMEWORK
+		exception.Status.StatusCode.Should().Be(StatusCode.Unavailable);
+#else
 		exception.Status.StatusCode.Should().Be(StatusCode.PermissionDenied);
 		exception.Status.Detail.Should().Be("Invalid api-key");
+#endif
 	}
 
 	[Fact]


### PR DESCRIPTION
This commit fixes a broken integration test on net462 with respect to the response status code when an invalid API key is received.

It seems like a system change on Windows may have broken this. The error message is now

> Error starting gRPC call. HttpRequestException: Error while copying content to a stream. IOException: The write operation failed, see inner exception. WinHttpException: Error 12030 calling WINHTTP_CALLBACK_STATUS_REQUEST_ERROR, 'The connection with the server was terminated abnormally'.