### PR TITLE
Update QdrantVersion to v1.5.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <PackageProjectUrl>https://github.com/qdrant/qdrant-dotnet</PackageProjectUrl>
     <PackageReleaseNotes>https://github.com/qdrant/qdrant-dotnet/releases</PackageReleaseNotes>
     <PackageTags>qdrant, database, vector, search</PackageTags>
-    <QdrantVersion>v1.4.1</QdrantVersion>
+    <QdrantVersion>v1.5.1</QdrantVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tests/Qdrant.Client.Tests/ApiKeyCertificateThumbprintTests.cs
+++ b/tests/Qdrant.Client.Tests/ApiKeyCertificateThumbprintTests.cs
@@ -40,7 +40,7 @@ public class ApiKeyCertificateThumbprintTests
 		});
 		var callInvoker = channel.Intercept(metadata =>
 		{
-			metadata.Add("api-key", "password!");
+			metadata.Add("api-key", ApiKey);
 			return metadata;
 		});
 
@@ -100,7 +100,7 @@ public class ApiKeyCertificateThumbprintTests
 		});
 		var callInvoker = channel.Intercept(metadata =>
 		{
-			metadata.Add("api-key", "password!");
+			metadata.Add("api-key", ApiKey);
 			return metadata;
 		});
 #else

--- a/tests/Qdrant.Client.Tests/Container/QdrantBuilder.cs
+++ b/tests/Qdrant.Client.Tests/Container/QdrantBuilder.cs
@@ -6,7 +6,7 @@ namespace Qdrant.Client.Tests.Container;
 
 public sealed class QdrantBuilder : ContainerBuilder<QdrantBuilder, QdrantContainer, QdrantConfiguration>
 {
-	public const string QdrantImage = "qdrant/qdrant:v1.4.1";
+	public const string QdrantImage = "qdrant/qdrant:" + QdrantGrpcClient.QdrantVersion;
 
 	public const ushort QdrantHttpPort = 6333;
 


### PR DESCRIPTION
This commit updates the qdrant version to v1.5.1, using the protos from this version to generate the client. The docker image version is also updated to use the qdrant version.