### PR TITLE
Add simpler instantiation options for Qdrant clientsSetup

### DIFF
--- a/src/Qdrant.Client/ClientConfiguration.cs
+++ b/src/Qdrant.Client/ClientConfiguration.cs
@@ -6,13 +6,12 @@ namespace Qdrant.Client;
 public class ClientConfiguration
 {
 	/// <summary>
-	/// The API key to sue
+	/// The API key to use.
 	/// </summary>
 	public string? ApiKey { get; set; }
 
 	/// <summary>
-	/// The certificate thumbprint to use when using a
-	/// self-signed certificate for TLS
+	/// The certificate thumbprint to use when using a self-signed certificate for TLS.
 	/// </summary>
 	public string? CertificateThumbprint { get; set; }
 }

--- a/src/Qdrant.Client/Grpc/QdrantChannel.cs
+++ b/src/Qdrant.Client/Grpc/QdrantChannel.cs
@@ -26,18 +26,15 @@ public class QdrantChannel : ChannelBase, IDisposable
 
 	/// <inheritdoc />
 	public override CallInvoker CreateCallInvoker()
-	{
-		if (Disposed)
-			throw new ObjectDisposedException(nameof(QdrantChannel));
-
-		return _configuration.ApiKey is null
-			? _channel.CreateCallInvoker()
-			: _channel.Intercept(metadata =>
-			{
-				metadata.Add("api-key", _configuration.ApiKey);
-				return metadata;
-			});
-	}
+		=> Disposed
+			? throw new ObjectDisposedException(nameof(QdrantChannel))
+			: _configuration.ApiKey is null
+				? _channel.CreateCallInvoker()
+				: _channel.Intercept(metadata =>
+				{
+					metadata.Add("api-key", _configuration.ApiKey);
+					return metadata;
+				});
 
 	/// <summary>
 	/// Creates a <see cref="QdrantChannel"/> for the specified address.

--- a/src/Qdrant.Client/Grpc/QdrantGrpcClient.cs
+++ b/src/Qdrant.Client/Grpc/QdrantGrpcClient.cs
@@ -1,23 +1,61 @@
 using Grpc.Core;
+using Grpc.Net.Client;
 
 namespace Qdrant.Client.Grpc;
 
 /// <summary>
 /// Low-level gRPC client for qdrant vector database. Consider using <see cref="QdrantClient" /> instead.
 /// </summary>
-public partial class QdrantGrpcClient
+public partial class QdrantGrpcClient : IDisposable
 {
 	private readonly CallInvoker _callInvoker;
+	private readonly QdrantChannel? _ownedChannel;
+	private bool _isDisposed;
 
-	/// <summary>Creates a new client for Qdrant</summary>
+	/// <summary>
+	/// Creates a new low-level gRPC client for Qdrant. Note that <see cref="QdrantClient" /> provides a higher-level,
+	/// easier to use alternative.
+	/// </summary>
+	/// <param name="host">The host to connect to.</param>
+	/// <param name="port">The port to connect to. Defaults to 6334.</param>
+	/// <param name="apiKey">The API key to use.</param>
+	public QdrantGrpcClient(string host, int port = 6334, string? apiKey = null)
+		: this(new UriBuilder("http", host, port).Uri, apiKey)
+	{
+	}
+
+	/// <summary>
+	/// Creates a new low-level gRPC client for Qdrant. Note that <see cref="QdrantClient" /> provides a higher-level,
+	/// easier to use alternative.
+	/// </summary>
+	/// <param name="address">The address to connect to.</param>
+	/// <param name="apiKey">The API key to use.</param>
+	public QdrantGrpcClient(System.Uri address, string? apiKey = null)
+	{
+		_ownedChannel = QdrantChannel.ForAddress(address, new() { ApiKey = apiKey });
+		_callInvoker = _ownedChannel.CreateCallInvoker();
+	}
+
+	/// <summary>
+	/// Creates a new low-level gRPC client for Qdrant. Note that <see cref="QdrantClient" /> provides a higher-level,
+	/// easier to use alternative.
+	/// </summary>
 	/// <param name="channel">The channel to use to make remote calls.</param>
+	/// <remarks>It is the responsibility of the caller to dispose of <paramref name="channel" />.</remarks>
 	public QdrantGrpcClient(ChannelBase channel) : this(channel.CreateCallInvoker())
 	{
 	}
 
+	/// <summary>
+	/// Creates a new low-level gRPC client for Qdrant, which uses a custom <c>CallInvoker</c>.
+	/// Note that <see cref="QdrantClient" /> provides a higher-level, easier to use alternative.
+	/// </summary>
 	/// <summary>Creates a new client for Qdrant that uses a custom <c>CallInvoker</c>.</summary>
 	/// <param name="callInvoker">The callInvoker to use to make remote calls.</param>
-	public QdrantGrpcClient(CallInvoker callInvoker) => _callInvoker = callInvoker;
+	/// <remarks>It is the responsibility of the caller to dispose of any resources associated with the
+	/// <paramref name="callInvoker" /> (e.g. the underlying <see cref="GrpcChannel" />.</remarks>
+	public QdrantGrpcClient(CallInvoker callInvoker)
+		=> _callInvoker = callInvoker;
 
 	/// <summary>Protected parameterless constructor to allow creation of test doubles.</summary>
 	protected QdrantGrpcClient() : this(new UnimplementedCallInvoker())
@@ -43,4 +81,16 @@ public partial class QdrantGrpcClient
 	/// Gets the client for Snapshots
 	/// </summary>
 	public virtual Snapshots.SnapshotsClient Snapshots => new(_callInvoker);
+
+	/// <inheritdoc />
+	public void Dispose()
+	{
+		if (_isDisposed)
+		{
+			return;
+		}
+
+		_ownedChannel?.Dispose();
+		_isDisposed = true;
+	}
 }

--- a/tests/Qdrant.Client.Tests/QdrantFixture.cs
+++ b/tests/Qdrant.Client.Tests/QdrantFixture.cs
@@ -64,7 +64,7 @@ public sealed class QdrantFixture : IAsyncLifetime
 		});
 		return new QdrantGrpcClient(callInvoker);
 #else
-		return new QdrantGrpcClient(QdrantChannel.ForAddress($"http://{Host}:{GrpcPort}"));
+		return new QdrantGrpcClient(Host, GrpcPort);
 #endif
 	}
 }


### PR DESCRIPTION
**Note: This PR is based on top of #11, review only starting from the 2nd commit**

This allows constructing both the lower-level QdrantGrpcClient and the higher-level QdrantClient via simple host/port or URI, removing the burden of creating a QdrantChannel from the user. When these instantiation methods are used, the client owns the gRPC channel is disposes it when it is disposed.