### PR TITLE
Add delay in between snapshot creation

### DIFF
--- a/src/Qdrant.Client/QdrantClient.cs
+++ b/src/Qdrant.Client/QdrantClient.cs
@@ -2528,7 +2528,7 @@ public class QdrantClient : IDisposable
 			readConsistency,
 			cancellationToken);
 
-		/// <summary>
+	/// <summary>
 	/// Look for the points which are closer to stored positive examples and at the same time further to negative
 	/// examples.
 	/// </summary>

--- a/tests/Qdrant.Client.Tests/Qdrant.Client.Tests.csproj
+++ b/tests/Qdrant.Client.Tests/Qdrant.Client.Tests.csproj
@@ -9,7 +9,6 @@
 
     <ItemGroup>
       <PackageReference Include="Moq" Version="4.18.4" />
-      <PackageReference Include="Polly" Version="8.0.0" />
       <PackageReference Include="Testcontainers" Version="3.1.0" />
       <PackageReference Include="xunit" Version="2.4.2" />
       <PackageReference Include="FluentAssertions" Version="6.11.0" />


### PR DESCRIPTION
snapshots are timestamped named to second precision. Wait more than 1 second to ensure we get 2 snapshots in list snapshots tests