### PR TITLE
Configure minver to bump versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+          fetch-depth: 0
+          filter: tree:0
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v3

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,8 +14,6 @@
 
   <PropertyGroup>
     <SolutionRoot>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))</SolutionRoot>
-    <MinVerMinimumMajorMinor>0.1</MinVerMinimumMajorMinor>
-    <MinVerIgnoreHeight>true</MinVerIgnoreHeight>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>False</IsPackable>


### PR DESCRIPTION
In preparation for release, configure [minver](https://github.com/adamralph/minver) to tag prereleases using `alpha.0` tags and commit height from last tag.

When checking out, fetch all commits so that we always pick up the latest tag. Can revisit this if it poses a problem in future.