### PR TITLE
Add System.Net references on net462

### DIFF
--- a/src/Qdrant.Client/CertificateValidation.cs
+++ b/src/Qdrant.Client/CertificateValidation.cs
@@ -1,3 +1,6 @@
+#if NETFRAMEWORK
+using System.Net.Http;
+#endif
 using System.Net.Security;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;

--- a/src/Qdrant.Client/Grpc/QdrantChannel.cs
+++ b/src/Qdrant.Client/Grpc/QdrantChannel.cs
@@ -1,3 +1,6 @@
+#if NETFRAMEWORK
+using System.Net.Http;
+#endif
 using Grpc.Core;
 using Grpc.Core.Interceptors;
 using Grpc.Net.Client;

--- a/tests/Qdrant.Client.Tests/ApiKeyCertificateThumbprintTests.cs
+++ b/tests/Qdrant.Client.Tests/ApiKeyCertificateThumbprintTests.cs
@@ -1,9 +1,11 @@
 #if NETFRAMEWORK
+using System.Net.Http;
 using Grpc.Core.Interceptors;
 using Grpc.Net.Client;
+#else
+using System.Security.Authentication;
 #endif
 
-using System.Security.Authentication;
 using FluentAssertions;
 using Grpc.Core;
 using Qdrant.Client.Grpc;
@@ -84,8 +86,7 @@ public class ApiKeyCertificateThumbprintTests
 
 		var exception = Assert.Throws<RpcException>(() => client.Qdrant.HealthCheck(new HealthCheckRequest()));
 #if NETFRAMEWORK
-		// TODO: This sometimes fails with StatusCode.PermissionDenied, but no idea why
-		exception.Status.StatusCode.Should().Be(StatusCode.Unavailable);
+		exception.Status.StatusCode.Should().BeOneOf(StatusCode.Unavailable, StatusCode.PermissionDenied);
 #else
 		exception.Status.StatusCode.Should().Be(StatusCode.PermissionDenied);
 		exception.Status.Detail.Should().Be("Invalid api-key");

--- a/tests/Qdrant.Client.Tests/QdrantFixture.cs
+++ b/tests/Qdrant.Client.Tests/QdrantFixture.cs
@@ -1,11 +1,12 @@
-using Qdrant.Client.Grpc;
-using Qdrant.Client.Tests.Container;
-using Xunit;
-
 #if NETFRAMEWORK
+using System.Net.Http;
 using Grpc.Core.Interceptors;
 using Grpc.Net.Client;
 #endif
+
+using Qdrant.Client.Grpc;
+using Qdrant.Client.Tests.Container;
+using Xunit;
 
 namespace Qdrant.Client;
 


### PR DESCRIPTION
This commit adds System.Net references on net462, and fixes the flaky test on net462 where a missing API key for a call to qdrant secured by an API key sometimes throws Unavailable, other times PermissionDenied status codes