### PR TITLE
RecreateCollection should not throw on non-existent collection

### DIFF
--- a/src/Qdrant.Client/QdrantClient.cs
+++ b/src/Qdrant.Client/QdrantClient.cs
@@ -422,7 +422,14 @@ public class QdrantClient : IDisposable
 		TimeSpan? timeout = null,
 		CancellationToken cancellationToken = default)
 	{
-		await DeleteCollectionAsync(collectionName, timeout, cancellationToken).ConfigureAwait(false);
+		try
+		{
+			await DeleteCollectionAsync(collectionName, timeout, cancellationToken).ConfigureAwait(false);
+		}
+		catch (QdrantException)
+		{
+			// swallow this exception as it indicates the collection did not exist
+		}
 
 		await CreateCollectionAsync(
 				collectionName, vectorsConfig, shardNumber, replicationFactor,
@@ -3266,7 +3273,7 @@ public class QdrantClient : IDisposable
 	/// <summary>
 	/// Use context and a target to find the most similar points to the target, constrained by the context.
 	/// </summary>
-	/// 
+	///
 	/// <remarks>
 	/// When using only the context (without a target), a special search - called context search - is performed where
 	/// pairs of points are used to generate a loss that guides the search towards the zone where
@@ -3276,13 +3283,13 @@ public class QdrantClient : IDisposable
 	/// Since the score of a context relates to loss, the maximum score a point can get is 0.0,
 	/// and it becomes normal that many points can have a score of 0.0.
 	///
-	/// When using target (with or without context), the score behaves a little different: The 
+	/// When using target (with or without context), the score behaves a little different: The
 	/// integer part of the score represents the rank with respect to the context, while the
-	/// decimal part of the score relates to the distance to the target. The context part of the score for 
-	/// each pair is calculated +1 if the point is closer to a positive than to a negative part of a pair, 
+	/// decimal part of the score relates to the distance to the target. The context part of the score for
+	/// each pair is calculated +1 if the point is closer to a positive than to a negative part of a pair,
 	/// and -1 otherwise.
 	/// </remarks>
-	/// 
+	///
 	/// <param name="collectionName">The name of the collection.</param>
 	/// <param name="target">Use this as the primary search objective.</param>
 	/// <param name="context">Search will be constrained by these pairs of examples.</param>

--- a/src/Qdrant.Client/QdrantClient.cs
+++ b/src/Qdrant.Client/QdrantClient.cs
@@ -3273,7 +3273,6 @@ public class QdrantClient : IDisposable
 	/// <summary>
 	/// Use context and a target to find the most similar points to the target, constrained by the context.
 	/// </summary>
-	///
 	/// <remarks>
 	/// When using only the context (without a target), a special search - called context search - is performed where
 	/// pairs of points are used to generate a loss that guides the search towards the zone where
@@ -3289,7 +3288,6 @@ public class QdrantClient : IDisposable
 	/// each pair is calculated +1 if the point is closer to a positive than to a negative part of a pair,
 	/// and -1 otherwise.
 	/// </remarks>
-	///
 	/// <param name="collectionName">The name of the collection.</param>
 	/// <param name="target">Use this as the primary search objective.</param>
 	/// <param name="context">Search will be constrained by these pairs of examples.</param>

--- a/tests/Qdrant.Client.Tests/CollectionTests.cs
+++ b/tests/Qdrant.Client.Tests/CollectionTests.cs
@@ -42,6 +42,15 @@ public class CollectionTests : IAsyncLifetime
 	}
 
 	[Fact]
+	public async Task RecreateCollection_with_no_existing_collection()
+	{
+		await _client.RecreateCollectionAsync(
+			"collection_1", new VectorParams { Size = 4, Distance = Distance.Cosine });
+
+		Assert.Contains(await _client.ListCollectionsAsync(), c => c == "collection_1");
+	}
+
+	[Fact]
 	public async Task ListCollections()
 	{
 		Assert.Empty(await _client.ListCollectionsAsync());


### PR DESCRIPTION
This commit fixes RecreateCollection to not throw when attempting to delete a collection that doesn't exist.

[The qdrant server `delete_collection` function returns `true` when the name is removed from the collections hashmap](https://github.com/qdrant/qdrant/blob/afc86328cb85dd6a224ac9f8b0171e2f0514bbd8/lib/storage/src/content_manager/toc/collection_meta_ops.rs#L125). It may make sense in future to return `Task<bool>` from the `DeleteCollectionAsync` method of the client, mapped to the `.Result` on the response. 

