### PR TITLE
feat: Enable Discover without target

### DIFF
--- a/src/Qdrant.Client/QdrantClient.cs
+++ b/src/Qdrant.Client/QdrantClient.cs
@@ -3306,8 +3306,120 @@ public class QdrantClient : IDisposable
 	/// </param>
 	public async Task<IReadOnlyList<ScoredPoint>> DiscoverAsync(
 		string collectionName,
+		TargetVector target,
 		IReadOnlyList<ContextExamplePair> context,
-		TargetVector? target = null,
+		Filter? filter = null,
+		uint limit = 10,
+		WithPayloadSelector? payloadSelector = null,
+		WithVectorsSelector? vectorsSelector = null,
+		SearchParams? searchParams = null,
+		ulong offset = 0,
+		string? usingVector = null,
+		LookupLocation? lookupFrom = null,
+		ReadConsistency? readConsistency = null,
+		ShardKeySelector? shardKeySelector = null,
+		TimeSpan? timeout = null,
+		CancellationToken cancellationToken = default)
+	{
+		var request = new DiscoverPoints
+		{
+			CollectionName = collectionName,
+			Target = target,
+			Context = { context },
+			Limit = limit,
+			Offset = offset,
+		};
+
+		if (filter is not null)
+			request.Filter = filter;
+
+		if (payloadSelector is not null)
+			request.WithPayload = payloadSelector;
+
+		if (vectorsSelector is not null)
+			request.WithVectors = vectorsSelector;
+
+		if (searchParams is not null)
+			request.Params = searchParams;
+
+		if (usingVector is not null)
+			request.Using = usingVector;
+
+		if (lookupFrom is not null)
+			request.LookupFrom = lookupFrom;
+
+		if (readConsistency is not null)
+			request.ReadConsistency = readConsistency;
+
+		if (timeout is not null)
+			request.Timeout = ConvertTimeout(timeout);
+
+		if (shardKeySelector is not null)
+			request.ShardKeySelector = shardKeySelector;
+
+		_logger.Discover(collectionName);
+
+		try
+		{
+			var response = await _pointsClient.DiscoverAsync(
+					request,
+					deadline: _grpcTimeout == default ? null : DateTime.UtcNow.Add(_grpcTimeout),
+					cancellationToken: cancellationToken)
+				.ConfigureAwait(false);
+
+			return response.Result;
+		}
+		catch (Exception e)
+		{
+			_logger.OperationFailed(nameof(LoggingExtensions.Discover), e);
+
+			throw;
+		}
+	}
+
+	/// <summary>
+	/// Use context to find points constrained by the context.
+	/// </summary>
+	///
+	/// <remarks>
+	/// When using only the context (without a target), a special search - called context search - is performed where
+	/// pairs of points are used to generate a loss that guides the search towards the zone where
+	/// most positive examples overlap. This means that the score minimizes the scenario of
+	/// finding a point closer to a negative than to a positive part of a pair.
+	///
+	/// Since the score of a context relates to loss, the maximum score a point can get is 0.0,
+	/// and it becomes normal that many points can have a score of 0.0.
+	///
+	/// When using target (with or without context), the score behaves a little different: The
+	/// integer part of the score represents the rank with respect to the context, while the
+	/// decimal part of the score relates to the distance to the target. The context part of the score for
+	/// each pair is calculated +1 if the point is closer to a positive than to a negative part of a pair,
+	/// and -1 otherwise.
+	/// </remarks>
+	///
+	/// <param name="collectionName">The name of the collection.</param>
+	/// <param name="context">Search will be constrained by these pairs of examples.</param>
+	/// <param name="filter">Filter conditions - return only those points that satisfy the specified conditions.</param>
+	/// <param name="limit">Max number of results.</param>
+	/// <param name="payloadSelector">Options for specifying which payload to include or not.</param>
+	/// <param name="vectorsSelector">Options for specifying which vectors to include in the response.</param>
+	/// <param name="searchParams">Search config.</param>
+	/// <param name="offset">Offset of the result.</param>
+	/// <param name="usingVector">
+	/// Define which vector to use for recommendation, if not specified - default vector.
+	/// </param>
+	/// <param name="lookupFrom">
+	/// Name of the collection to use for points lookup, if not specified - use current collection.
+	/// </param>
+	/// <param name="readConsistency">Options for specifying read consistency guarantees.</param>
+	/// <param name="timeout">If set, overrides global timeout setting for this request.</param>
+	/// <param name="shardKeySelector">Option for custom sharding to specify used shard keys.</param>
+	/// <param name="cancellationToken">
+	/// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None" />.
+	/// </param>
+	public async Task<IReadOnlyList<ScoredPoint>> DiscoverAsync(
+		string collectionName,
+		IReadOnlyList<ContextExamplePair> context,
 		Filter? filter = null,
 		uint limit = 10,
 		WithPayloadSelector? payloadSelector = null,
@@ -3328,9 +3440,6 @@ public class QdrantClient : IDisposable
 			Limit = limit,
 			Offset = offset,
 		};
-
-		if (target is not null)
-			request.Target = target;
 
 		if (filter is not null)
 			request.Filter = filter;

--- a/src/Qdrant.Client/QdrantClient.cs
+++ b/src/Qdrant.Client/QdrantClient.cs
@@ -3383,8 +3383,8 @@ public class QdrantClient : IDisposable
 	/// </remarks>
 	///
 	/// <param name="collectionName">The name of the collection.</param>
-	/// <param name="context">Search will be constrained by these pairs of examples.</param>
 	/// <param name="target">Use this as the primary search objective.</param>
+	/// <param name="context">Search will be constrained by these pairs of examples.</param>
 	/// <param name="filter">Filter conditions - return only those points that satisfy the specified conditions.</param>
 	/// <param name="limit">Max number of results.</param>
 	/// <param name="payloadSelector">Options for specifying which payload to include or not.</param>

--- a/src/Qdrant.Client/QdrantClient.cs
+++ b/src/Qdrant.Client/QdrantClient.cs
@@ -3266,7 +3266,7 @@ public class QdrantClient : IDisposable
 	/// <summary>
 	/// Use context and a target to find the most similar points to the target, constrained by the context.
 	/// </summary>
-	/// 
+	///
 	/// <remarks>
 	/// When using only the context (without a target), a special search - called context search - is performed where
 	/// pairs of points are used to generate a loss that guides the search towards the zone where
@@ -3276,16 +3276,16 @@ public class QdrantClient : IDisposable
 	/// Since the score of a context relates to loss, the maximum score a point can get is 0.0,
 	/// and it becomes normal that many points can have a score of 0.0.
 	///
-	/// When using target (with or without context), the score behaves a little different: The 
+	/// When using target (with or without context), the score behaves a little different: The
 	/// integer part of the score represents the rank with respect to the context, while the
-	/// decimal part of the score relates to the distance to the target. The context part of the score for 
-	/// each pair is calculated +1 if the point is closer to a positive than to a negative part of a pair, 
+	/// decimal part of the score relates to the distance to the target. The context part of the score for
+	/// each pair is calculated +1 if the point is closer to a positive than to a negative part of a pair,
 	/// and -1 otherwise.
 	/// </remarks>
-	/// 
+	///
 	/// <param name="collectionName">The name of the collection.</param>
-	/// <param name="target">Use this as the primary search objective.</param>
 	/// <param name="context">Search will be constrained by these pairs of examples.</param>
+	/// <param name="target">Use this as the primary search objective.</param>
 	/// <param name="filter">Filter conditions - return only those points that satisfy the specified conditions.</param>
 	/// <param name="limit">Max number of results.</param>
 	/// <param name="payloadSelector">Options for specifying which payload to include or not.</param>
@@ -3306,8 +3306,8 @@ public class QdrantClient : IDisposable
 	/// </param>
 	public async Task<IReadOnlyList<ScoredPoint>> DiscoverAsync(
 		string collectionName,
-		TargetVector target,
 		IReadOnlyList<ContextExamplePair> context,
+		TargetVector? target = null,
 		Filter? filter = null,
 		uint limit = 10,
 		WithPayloadSelector? payloadSelector = null,
@@ -3324,11 +3324,13 @@ public class QdrantClient : IDisposable
 		var request = new DiscoverPoints
 		{
 			CollectionName = collectionName,
-			Target = target,
 			Context = { context },
 			Limit = limit,
 			Offset = offset,
 		};
+
+		if (target is not null)
+			request.Target = target;
 
 		if (filter is not null)
 			request.Filter = filter;

--- a/tests/Qdrant.Client.Tests/QdrantFixture.cs
+++ b/tests/Qdrant.Client.Tests/QdrantFixture.cs
@@ -17,8 +17,7 @@ public sealed class QdrantFixture : IAsyncLifetime
 {
 	private readonly QdrantContainer _container;
 
-	public QdrantFixture()
-	{
+	public QdrantFixture() =>
 #if NETFRAMEWORK
 		// .NET Framework must use TLS with HTTPS
 		_container = new QdrantBuilder()
@@ -31,7 +30,7 @@ public sealed class QdrantFixture : IAsyncLifetime
 #else
 		_container = new QdrantBuilder().Build();
 #endif
-	}
+
 
 	public string Host => _container.Hostname;
 


### PR DESCRIPTION
This PR marks the `target` argument of the Discover API as optional. Enabling discovery with target - [Context search](https://qdrant.tech/documentation/concepts/explore/#context-search)

W̶e̶ c̶o̶u̶l̶d̶ a̶d̶d̶ a̶n̶o̶t̶h̶e̶r̶ o̶v̶e̶r̶l̶o̶a̶d̶ f̶o̶r̶ t̶h̶i̶s̶ f̶u̶n̶c̶t̶i̶o̶n̶ t̶o̶ p̶r̶e̶v̶e̶n̶t̶ t̶h̶e̶ b̶r̶e̶a̶k̶i̶n̶g̶ c̶h̶a̶n̶g̶e̶, b̶u̶t̶ t̶h̶i̶s̶ r̶e̶f̶a̶c̶t̶o̶r̶ s̶e̶e̶m̶s̶ a̶p̶p̶r̶o̶p̶r̶i̶a̶t̶e̶ a̶s̶ p̶e̶r̶ t̶h̶e̶ b̶e̶h̶a̶v̶i̶o̶u̶r̶. 
Added as an overload.

B̶R̶E̶A̶K̶I̶N̶G̶ change!!