### PR TITLE
chore: updated convenience methods

### DIFF
--- a/src/Qdrant.Client/Grpc/PointsSelector.cs
+++ b/src/Qdrant.Client/Grpc/PointsSelector.cs
@@ -8,12 +8,22 @@ public partial class PointsSelector
 	/// <summary>
 	/// Implicitly converts a <see cref="Guid" /> ID to a new instance of <see cref="PointsSelector"/>
 	/// </summary>
-	public static implicit operator PointsSelector(Guid id)
-		=> new() { Points = new PointsIdsList { Ids = { new PointId { Uuid = id.ToString() } } } };
+	public static implicit operator PointsSelector(Guid id) => new Guid[] { id };
 
 	/// <summary>
 	/// Implicitly converts a <see cref="ulong" /> ID to a new instance of <see cref="PointsSelector"/>
 	/// </summary>
-	public static implicit operator PointsSelector(ulong id)
-		=> new() { Points = new PointsIdsList { Ids = { new PointId { Num = id } } } };
+	public static implicit operator PointsSelector(ulong id) => new ulong[] { id };
+
+	/// <summary>
+	/// Implicitly converts an array of <see cref="ulong" /> ID to a new instance of <see cref="PointsSelector"/>
+	/// </summary>
+	public static implicit operator PointsSelector(ulong[] ids) =>
+		new() { Points = new PointsIdsList { Ids = { ids.Select(id => (PointId)id).ToArray() } } };
+
+	/// <summary>
+	/// Implicitly converts an array of <see cref="Guid" /> ID to a new instance of <see cref="PointsSelector"/>
+	/// </summary>
+	public static implicit operator PointsSelector(Guid[] ids) =>
+		new() { Points = new PointsIdsList { Ids = { ids.Select(id => (PointId)id).ToArray() } } };
 }

--- a/src/Qdrant.Client/Grpc/PointsSelector.cs
+++ b/src/Qdrant.Client/Grpc/PointsSelector.cs
@@ -8,12 +8,14 @@ public partial class PointsSelector
 	/// <summary>
 	/// Implicitly converts a <see cref="Guid" /> ID to a new instance of <see cref="PointsSelector"/>
 	/// </summary>
-	public static implicit operator PointsSelector(Guid id) => new Guid[] { id };
+	public static implicit operator PointsSelector(Guid id) =>
+		new() { Points = new PointsIdsList { Ids = { new PointId { Uuid = id.ToString() } } } };
 
 	/// <summary>
 	/// Implicitly converts a <see cref="ulong" /> ID to a new instance of <see cref="PointsSelector"/>
 	/// </summary>
-	public static implicit operator PointsSelector(ulong id) => new ulong[] { id };
+	public static implicit operator PointsSelector(ulong id) =>
+		new() { Points = new PointsIdsList { Ids = { new PointId { Num = id } } } };
 
 	/// <summary>
 	/// Implicitly converts an array of <see cref="ulong" /> ID to a new instance of <see cref="PointsSelector"/>

--- a/src/Qdrant.Client/Grpc/PointsSelector.cs
+++ b/src/Qdrant.Client/Grpc/PointsSelector.cs
@@ -19,11 +19,11 @@ public partial class PointsSelector
 	/// Implicitly converts an array of <see cref="ulong" /> ID to a new instance of <see cref="PointsSelector"/>
 	/// </summary>
 	public static implicit operator PointsSelector(ulong[] ids) =>
-		new() { Points = new PointsIdsList { Ids = { ids.Select(id => (PointId)id).ToArray() } } };
+		new() { Points = new PointsIdsList { Ids = { ids.Select(id => (PointId)id) } } };
 
 	/// <summary>
 	/// Implicitly converts an array of <see cref="Guid" /> ID to a new instance of <see cref="PointsSelector"/>
 	/// </summary>
 	public static implicit operator PointsSelector(Guid[] ids) =>
-		new() { Points = new PointsIdsList { Ids = { ids.Select(id => (PointId)id).ToArray() } } };
+		new() { Points = new PointsIdsList { Ids = { ids.Select(id => (PointId)id) } } };
 }

--- a/src/Qdrant.Client/Grpc/Value.cs
+++ b/src/Qdrant.Client/Grpc/Value.cs
@@ -40,4 +40,11 @@ public partial class Value
 		var listValues = values.Select(s => new Value { StringValue = s });
 		return new Value { ListValue = new ListValue { Values = { listValues } } };
 	}
+
+	/// <summary>
+	/// Implicitly converts an array of <see cref="Value"/> to a new instance of <see cref="Value"/> with <see cref="ListValue"/>
+	/// </summary>
+	/// <param name="values">the array of <see cref="Value"/></param>
+	/// <returns>a new instance of <see cref="Value"/></returns>
+	public static implicit operator Value(Value[] values) => new Value { ListValue = new ListValue { Values = { values.AsEnumerable() } } };
 }

--- a/src/Qdrant.Client/Grpc/WithPayloadSelector.cs
+++ b/src/Qdrant.Client/Grpc/WithPayloadSelector.cs
@@ -19,31 +19,4 @@ public partial class WithPayloadSelector
 	/// <returns>a new instance of <see cref="WithPayloadSelector"/></returns>
 	public static implicit operator WithPayloadSelector(string[] fields) =>
 		new() { Include = new PayloadIncludeSelector { Fields = { fields } } };
-
-	/// <summary>
-	/// Negates the <see cref="WithPayloadSelector"/> condition.
-	/// </summary>
-	/// <param name="selector"><see cref="WithPayloadSelector"/> to negate.</param>
-	/// <returns>a new instance of <see cref="WithPayloadSelector"/></returns>
-	public static WithPayloadSelector operator !(WithPayloadSelector selector)
-	{
-		if (selector.HasEnable)
-		{
-			return new WithPayloadSelector { Enable = !selector.Enable };
-		}
-		else if (selector.Include is not null)
-		{
-			return new WithPayloadSelector
-			{
-				Exclude = new PayloadExcludeSelector { Fields = { selector.Include.Fields } }
-			};
-		}
-		else
-		{
-			return new WithPayloadSelector
-			{
-				Include = new PayloadIncludeSelector { Fields = { selector.Exclude.Fields } }
-			};
-		}
-	}
 }

--- a/src/Qdrant.Client/Grpc/WithPayloadSelector.cs
+++ b/src/Qdrant.Client/Grpc/WithPayloadSelector.cs
@@ -11,4 +11,39 @@ public partial class WithPayloadSelector
 	/// <param name="enable">If <code>true</code> return all payload, if <code>false</code> then none</param>
 	/// <returns>a new instance of <see cref="WithPayloadSelector"/></returns>
 	public static implicit operator WithPayloadSelector(bool enable) => new() { Enable = enable };
+
+	/// <summary>
+	/// Implicitly converts <see cref="string"/> to a new instance of <see cref="WithPayloadSelector"/>
+	/// </summary>
+	/// <param name="fields">List of fields in the payload to return.</param>
+	/// <returns>a new instance of <see cref="WithPayloadSelector"/></returns>
+	public static implicit operator WithPayloadSelector(string[] fields) =>
+		new() { Include = new PayloadIncludeSelector { Fields = { fields } } };
+
+	/// <summary>
+	/// Negates the <see cref="WithPayloadSelector"/> condition.
+	/// </summary>
+	/// <param name="selector"><see cref="WithPayloadSelector"/> to negate.</param>
+	/// <returns>a new instance of <see cref="WithPayloadSelector"/></returns>
+	public static WithPayloadSelector operator !(WithPayloadSelector selector)
+	{
+		if (selector.HasEnable)
+		{
+			return new WithPayloadSelector { Enable = !selector.Enable };
+		}
+		else if (selector.Include is not null)
+		{
+			return new WithPayloadSelector
+			{
+				Exclude = new PayloadExcludeSelector { Fields = { selector.Include.Fields } }
+			};
+		}
+		else
+		{
+			return new WithPayloadSelector
+			{
+				Include = new PayloadIncludeSelector { Fields = { selector.Exclude.Fields } }
+			};
+		}
+	}
 }

--- a/src/Qdrant.Client/Grpc/WithVectorsSelector.cs
+++ b/src/Qdrant.Client/Grpc/WithVectorsSelector.cs
@@ -15,7 +15,7 @@ public partial class WithVectorsSelector
 	/// <summary>
 	/// Implicitly converts an array <see cref="string"/> to a new instance of <see cref="WithPayloadSelector"/>
 	/// </summary>
-	/// <param name="vectors">List of vector names to return.</param>
+	/// <param name="vectors">List of vector names to include in the response.</param>
 	/// <returns>a new instance of <see cref="WithPayloadSelector"/></returns>
 	public static implicit operator WithVectorsSelector(string[] vectors) =>
 		new() { Include = new() { Names = { vectors } } };

--- a/src/Qdrant.Client/Grpc/WithVectorsSelector.cs
+++ b/src/Qdrant.Client/Grpc/WithVectorsSelector.cs
@@ -11,4 +11,12 @@ public partial class WithVectorsSelector
 	/// <param name="enable">If <code>true</code> return all vectors, if <code>false</code> then none</param>
 	/// <returns>a new instance of <see cref="WithPayloadSelector"/></returns>
 	public static implicit operator WithVectorsSelector(bool enable) => new() { Enable = enable };
+
+	/// <summary>
+	/// Implicitly converts an array <see cref="string"/> to a new instance of <see cref="WithPayloadSelector"/>
+	/// </summary>
+	/// <param name="vectors">List of vector names to return.</param>
+	/// <returns>a new instance of <see cref="WithPayloadSelector"/></returns>
+	public static implicit operator WithVectorsSelector(string[] vectors) =>
+		new() { Include = new() { Names = { vectors } } };
 }


### PR DESCRIPTION
This PR adds convenience methods for
- Creating `PointsSelector` from a list of values.
- Creating a list of `Value` for payloads.
- Payload field selectors(Include from string[], ! operator to Exclude)
- Vector selectors