### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
 
     - name: Build
       run: ./build.sh build
@@ -45,7 +45,7 @@ jobs:
       shell: bash
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
           name: QdrantNupkg
           path: nuget


### PR DESCRIPTION
This commit updates the GitHub actions to use versions based on node 20 rather than node 16, which is deprecated.