### PR TITLE
Hide package and proto files

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -18,9 +18,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="$(SolutionRoot)README.md" Pack="true" PackagePath="." />
-    <None Include="$(SolutionRoot)LICENSE" Pack="true" PackagePath="." />
-    <None Include="$(SolutionRoot)nuget-icon.png" Pack="true" PackagePath="." />
+    <None Include="$(SolutionRoot)README.md" Pack="true" PackagePath="." Visible="false" />
+    <None Include="$(SolutionRoot)LICENSE" Pack="true" PackagePath="." Visible="false" />
+    <None Include="$(SolutionRoot)nuget-icon.png" Pack="true" PackagePath="." Visible="false" />
   </ItemGroup>
 
   <!-- suppress warnings for netstandard2.0 xml docs -->

--- a/src/Qdrant.Client/Qdrant.Client.csproj
+++ b/src/Qdrant.Client/Qdrant.Client.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Protobuf Include="..\..\protos\$(QdrantVersion)\*.proto" GrpcServices="Client" Link="Grpc\protos\$(QdrantVersion)\*.proto" />
+    <Protobuf Include="..\..\protos\$(QdrantVersion)\*.proto" GrpcServices="Client" Link="Grpc\protos\$(QdrantVersion)\*.proto" Visible="false" />
   </ItemGroup>
 
 


### PR DESCRIPTION
This commit hides package and proto files in IDEs. These files are needed for nuget package building and proto generation only, and don't need to be navigable in an IDE.