### PR TITLE
Add Health check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ protos
 
 *.sln.DotSettings.user
 output
+.vs

--- a/tests/Qdrant.Client.Tests/HealthCheckTests.cs
+++ b/tests/Qdrant.Client.Tests/HealthCheckTests.cs
@@ -1,0 +1,31 @@
+using FluentAssertions;
+using Grpc.Core;
+using Xunit;
+
+namespace Qdrant.Client
+{
+	public class HealthCheckTests : IClassFixture<QdrantFixture>
+	{
+		private readonly QdrantClient _client;
+
+		public HealthCheckTests(QdrantFixture qdrantFixture) => _client = qdrantFixture.CreateClient();
+
+		[Fact]
+		public async Task Server_Should_Be_Healthy()
+		{
+			var response = await _client.HealthAsync();
+
+			response.Title.Should().NotBeNullOrEmpty();
+			response.Version.Should().NotBeNullOrEmpty();
+		}
+		[Fact]
+		public async Task Server_Should_Be_UnHealthy()
+		{
+			var client = new QdrantClient("localhost", 9999);
+			;
+
+			await Assert.ThrowsAsync<RpcException>(async () => await client.HealthAsync());
+		}
+
+	}
+}


### PR DESCRIPTION
This pull request introduces a new health check feature for the Qdrant service and includes associated tests. The most important changes involve adding the health check method to the `QdrantClient` class and creating unit tests to verify the functionality.

### New Feature: Health Check

* [`src/Qdrant.Client/QdrantClient.cs`](diffhunk://#diff-5412ce283c3299e57b16983d036dce4adbcadd4c42f550126650dcbf503925e2R4291-R4305): Added a new method `HealthAsync` to asynchronously check the health of the Qdrant service. This method produces an error when the server is unavailable.
* [`tests/Qdrant.Client.Tests/HealthCheckTests.cs`](diffhunk://#diff-1fc61049528cbb875432a0e442b04c7d749bbb8726f7b3a7eef1e84e89a43432R1-R31): Created new unit tests for the health check functionality, including tests for both healthy and unhealthy server states.


Fixes: #70 