### PR TITLE
Bump dependency versions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MinVer" Version="4.3.0" PrivateAssets="all"/>
+    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="all"/>
   </ItemGroup>
 
 </Project>

--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bullseye" Version="4.2.1"/>
-    <PackageReference Include="SimpleExec" Version="11.0.0"/>
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
-    <PackageReference Include="SharpCompress" Version="0.33.0" />
+    <PackageReference Include="Bullseye" Version="5.0.0" />
+    <PackageReference Include="SimpleExec" Version="12.0.0" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="SharpCompress" Version="0.38.0" />
   </ItemGroup>
 
 </Project>

--- a/build/Main.cs
+++ b/build/Main.cs
@@ -75,7 +75,8 @@ cmd.SetHandler(async () =>
 		var reader = ReaderFactory.Open(gzip);
 		while (reader.MoveToNextEntry())
 		{
-			if (!reader.Entry.IsDirectory && protoFileRegex.IsMatch(reader.Entry.Key) && !privateProtoFileRegex.IsMatch(reader.Entry.Key))
+			var entry = reader.Entry;
+			if (!entry.IsDirectory && protoFileRegex.IsMatch(entry.Key!) && !privateProtoFileRegex.IsMatch(entry.Key!))
 				reader.WriteEntryToDirectory(protosTagDir);
 		}
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -29,8 +29,8 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0.1" PrivateAssets="All" />
-    <PackageReference Include="SauceControl.InheritDoc" Version="1.3.0" PrivateAssets="All" />
+    <PackageReference Include="SauceControl.InheritDoc" Version="2.0.1" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/Qdrant.Client/Qdrant.Client.csproj
+++ b/src/Qdrant.Client/Qdrant.Client.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.24.2" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.57.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.57.0">
+    <PackageReference Include="Google.Protobuf" Version="3.28.2" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.66.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.67.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Qdrant.Client.Tests/Container/QdrantBuilder.cs
+++ b/tests/Qdrant.Client.Tests/Container/QdrantBuilder.cs
@@ -31,7 +31,7 @@ public sealed class QdrantBuilder : ContainerBuilder<QdrantBuilder, QdrantContai
 	public override QdrantContainer Build()
 	{
 		Validate();
-		return new QdrantContainer(DockerResourceConfiguration, TestcontainersSettings.Logger);
+		return new QdrantContainer(DockerResourceConfiguration);
 	}
 
 	protected override QdrantBuilder Init() =>

--- a/tests/Qdrant.Client.Tests/Container/QdrantContainer.cs
+++ b/tests/Qdrant.Client.Tests/Container/QdrantContainer.cs
@@ -5,7 +5,7 @@ namespace Qdrant.Client.Tests.Container;
 
 public class QdrantContainer : DockerContainer
 {
-	public QdrantContainer(QdrantConfiguration configuration, ILogger logger) : base(configuration, logger)
+	public QdrantContainer(QdrantConfiguration configuration) : base(configuration)
 	{
 	}
 }

--- a/tests/Qdrant.Client.Tests/HealthCheckTests.cs
+++ b/tests/Qdrant.Client.Tests/HealthCheckTests.cs
@@ -18,14 +18,12 @@ namespace Qdrant.Client
 			response.Title.Should().NotBeNullOrEmpty();
 			response.Version.Should().NotBeNullOrEmpty();
 		}
+
 		[Fact]
 		public async Task Server_Should_Be_UnHealthy()
 		{
 			var client = new QdrantClient("localhost", 9999);
-			;
-
 			await Assert.ThrowsAsync<RpcException>(async () => await client.HealthAsync());
 		}
-
 	}
 }

--- a/tests/Qdrant.Client.Tests/PointTests.cs
+++ b/tests/Qdrant.Client.Tests/PointTests.cs
@@ -280,7 +280,7 @@ public class PointTests : IAsyncLifetime
 			positive: new PointId[] { 9 },
 			groupSize: 2);
 
-		Assert.Equal(1, groups.Count);
+		Assert.Single(groups);
 		Assert.Single(groups, g => g.Hits.Count == 2);
 	}
 
@@ -491,7 +491,7 @@ public class PointTests : IAsyncLifetime
 			prefetch: new List<PrefetchQuery> { new() { Limit = 1 } }
 		);
 
-		Assert.Equal(1, points.Count);
+		Assert.Single(points);
 	}
 
 	[Fact]

--- a/tests/Qdrant.Client.Tests/Qdrant.Client.Tests.csproj
+++ b/tests/Qdrant.Client.Tests/Qdrant.Client.Tests.csproj
@@ -8,13 +8,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Moq" Version="4.18.4" />
-      <PackageReference Include="Testcontainers" Version="3.1.0" />
-      <PackageReference Include="xunit" Version="2.4.2" />
-      <PackageReference Include="FluentAssertions" Version="6.11.0" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-      <PackageReference Include="JunitXml.TestLogger" Version="3.0.134" />
-      <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PackageReference Include="Moq" Version="4.20.72" />
+      <PackageReference Include="Testcontainers" Version="3.10.0" />
+      <PackageReference Include="xunit" Version="2.9.2" />
+      <PackageReference Include="FluentAssertions" Version="6.12.1" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+      <PackageReference Include="JunitXml.TestLogger" Version="4.0.254" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>   
       </PackageReference>
@@ -22,7 +22,7 @@
     </ItemGroup>
   
     <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-      <PackageReference Include="System.Net.Http.WinHttpHandler" Version="7.0.0" />
+      <PackageReference Include="System.Net.Http.WinHttpHandler" Version="8.0.2" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This PR bumps the versions of dependencies. 

Some of the version bumps for the test and build projects are across major versions that created some API breaking changes, which have been addressed. 

The client project version bumps for packages referenced at runtime are all minor version increases.

Solution compiles and all tests pass.