### PR TITLE
Bump dependencies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,6 +20,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <MinVerMinimumMajorMinor>1.0</MinVerMinimumMajorMinor>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputType>Exe</OutputType>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -31,6 +31,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0.1" PrivateAssets="All" />
-    <PackageReference Include="SauceControl.InheritDoc" Version="2.0.1" PrivateAssets="All" />
+    <PackageReference Include="SauceControl.InheritDoc" Version="2.0.2" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/Qdrant.Client/Qdrant.Client.csproj
+++ b/src/Qdrant.Client/Qdrant.Client.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.28.2" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.66.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.67.0">
+    <PackageReference Include="Google.Protobuf" Version="3.29.3" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.67.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.69.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Qdrant.Client.Tests/Qdrant.Client.Tests.csproj
+++ b/tests/Qdrant.Client.Tests/Qdrant.Client.Tests.csproj
@@ -9,11 +9,11 @@
 
     <ItemGroup>
       <PackageReference Include="Moq" Version="4.20.72" />
-      <PackageReference Include="Testcontainers" Version="3.10.0" />
-      <PackageReference Include="xunit" Version="2.9.2" />
-      <PackageReference Include="FluentAssertions" Version="6.12.1" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-      <PackageReference Include="JunitXml.TestLogger" Version="4.0.254" />
+      <PackageReference Include="Testcontainers" Version="4.1.0" />
+      <PackageReference Include="xunit" Version="2.9.3" />
+      <PackageReference Include="FluentAssertions" Version="7.0.0" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+      <PackageReference Include="JunitXml.TestLogger" Version="5.0.0" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>   
@@ -22,7 +22,7 @@
     </ItemGroup>
   
     <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-      <PackageReference Include="System.Net.Http.WinHttpHandler" Version="8.0.2" />
+      <PackageReference Include="System.Net.Http.WinHttpHandler" Version="9.0.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Enable built-in .NET analyzers on .NET Framework. see https://github.com/dotnet/roslyn-analyzers?tab=readme-ov-file#microsoftcodeanalysisnetanalyzers