### PR TITLE
Pin SDK to .net 8

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "8.0.100",
-    "rollForward": "latestMajor"
+    "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
This commit pins the SDK version used for compilation to .net 8 to match the build and test projects.

There is an issue with `dotnet format` command when building with certain versions of .net 9 SDK that results in:

```
Unhandled exception: System.Exception: source text did not have an identifiable encoding
```

Looks related to https://github.com/dotnet/sdk/issues/46780, which is fixed in later .net 9 versions. The build doesn't need .net 9, so best to pin to .net 8.