### PR TITLE
Pin FluentAssertions

### DIFF
--- a/tests/Qdrant.Client.Tests/Qdrant.Client.Tests.csproj
+++ b/tests/Qdrant.Client.Tests/Qdrant.Client.Tests.csproj
@@ -11,7 +11,7 @@
       <PackageReference Include="Moq" Version="4.20.72" />
       <PackageReference Include="Testcontainers" Version="4.1.0" />
       <PackageReference Include="xunit" Version="2.9.3" />
-      <PackageReference Include="FluentAssertions" Version="7.0.0" />
+      <PackageReference Include="FluentAssertions" Version="[7.0.0]" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
       <PackageReference Include="JunitXml.TestLogger" Version="5.0.0" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">


### PR DESCRIPTION
Relates https://github.com/qdrant/qdrant-dotnet/pull/79

The version pinning was lost in merges in the related PR. This commit addresses that.