### PR TITLE
Payload Schema type structural tests

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,6 +21,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <MinVerMinimumMajorMinor>1.0</MinVerMinimumMajorMinor>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AssemblyOriginatorKeyFile>$(SolutionRoot)build\keys\keypair.snk</AssemblyOriginatorKeyFile>
+    <PublicKey>0024000004800000940000000602000000240000525341310004000001000100ed1d190ea5406d996c0f5b1a8acbf865fab69e948e50f3621ee36a586566357356ccb63d2bddbc967bef647c2ea7e2871c479c4aaf9dc4d4570022e0dd23d2126e60a69600d6d446b64c4413dcd07d92ee208a59f3531afc6a2afd512e8cbbdf8576887a7eaf72933f041e7134f78b358ee97fc66e80c4604c6bad7a5124fcca</PublicKey>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,10 +3,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-
     <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>$(SolutionRoot)build\keys\keypair.snk</AssemblyOriginatorKeyFile>
-
     <PackageIcon>nuget-icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>

--- a/src/Qdrant.Client/Qdrant.Client.csproj
+++ b/src/Qdrant.Client/Qdrant.Client.csproj
@@ -20,7 +20,10 @@
     <Protobuf Include="..\..\protos\$(QdrantVersion)\*.proto" GrpcServices="Client" Link="Grpc\protos\$(QdrantVersion)\*.proto" Visible="false" />
   </ItemGroup>
 
-
+  <ItemGroup>
+    <InternalsVisibleTo Include="$(AssemblyName).Tests" Key="$(PublicKey)" />
+  </ItemGroup>
+  
   <PropertyGroup>
     <GeneratedText><![CDATA[
 namespace Qdrant.Client.Grpc%3B

--- a/src/Qdrant.Client/QdrantClient.cs
+++ b/src/Qdrant.Client/QdrantClient.cs
@@ -2372,19 +2372,7 @@ public class QdrantClient : IDisposable
 			CollectionName = collectionName,
 			FieldName = fieldName,
 			Wait = wait,
-			FieldType = schemaType switch
-			{
-				PayloadSchemaType.Keyword => FieldType.Keyword,
-				PayloadSchemaType.Integer => FieldType.Integer,
-				PayloadSchemaType.Float => FieldType.Float,
-				PayloadSchemaType.Bool => FieldType.Bool,
-				PayloadSchemaType.Geo => FieldType.Geo,
-				PayloadSchemaType.Text => FieldType.Text,
-				PayloadSchemaType.Datetime => FieldType.Datetime,
-				PayloadSchemaType.Uuid => FieldType.Uuid,
-
-				_ => throw new ArgumentException("Invalid PayloadSchemaType: " + schemaType, nameof(schemaType))
-			}
+			FieldType = FieldTypeFromPayloadSchemaType(schemaType)
 		};
 
 		if (indexParams is not null)
@@ -4000,7 +3988,7 @@ public class QdrantClient : IDisposable
 	/// Universally query points.
 	/// Covers all capabilities of search, recommend, discover, filters.
 	/// Also enables hybrid and multi-stage queries.
-	/// 
+	///
 	/// </summary>
 	/// <param name="collectionName">The name of the collection.</param>
 	/// <param name="query">Query to perform. If missing, returns points ordered by their IDs.</param>
@@ -4100,7 +4088,7 @@ public class QdrantClient : IDisposable
 	/// Universally query points in batch.
 	/// Covers all capabilities of search, recommend, discover, filters.
 	/// Also enables hybrid and multi-stage queries.
-	/// 
+	///
 	/// </summary>
 	/// <param name="collectionName">The name of the collection.</param>
 	/// <param name="queries">The queries to be performed in the batch.</param>
@@ -4153,7 +4141,7 @@ public class QdrantClient : IDisposable
 	/// Universally query points.
 	/// Covers all capabilities of search, recommend, discover, filters.
 	/// Grouped by a payload field.
-	/// 
+	///
 	/// </summary>
 	/// <param name="collectionName">The name of the collection.</param>
 	/// <param name="groupBy">Payload field to group by, must be a string or number field.</param>
@@ -4520,6 +4508,21 @@ public class QdrantClient : IDisposable
 			new HealthCheckRequest(),
 			deadline: _grpcTimeout == default ? null : DateTime.UtcNow.Add(_grpcTimeout),
 			cancellationToken: cancellationToken).ConfigureAwait(false);
+
+	internal static FieldType FieldTypeFromPayloadSchemaType(PayloadSchemaType schemaType) =>
+		schemaType switch
+		{
+			PayloadSchemaType.Keyword => FieldType.Keyword,
+			PayloadSchemaType.Integer => FieldType.Integer,
+			PayloadSchemaType.Float => FieldType.Float,
+			PayloadSchemaType.Bool => FieldType.Bool,
+			PayloadSchemaType.Geo => FieldType.Geo,
+			PayloadSchemaType.Text => FieldType.Text,
+			PayloadSchemaType.Datetime => FieldType.Datetime,
+			PayloadSchemaType.Uuid => FieldType.Uuid,
+
+			_ => throw new ArgumentException("Invalid PayloadSchemaType: " + schemaType, nameof(schemaType))
+		};
 
 	private static void Populate<T>(RepeatedField<T> repeatedField, ReadOnlyMemory<T> memory)
 	{

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+</Project>

--- a/tests/Qdrant.Client.Tests/StructuralTests.cs
+++ b/tests/Qdrant.Client.Tests/StructuralTests.cs
@@ -1,0 +1,25 @@
+using Qdrant.Client.Grpc;
+using Xunit;
+
+namespace Qdrant.Client;
+
+public class StructuralTests
+{
+	[Fact]
+	public void All_PayloadSchemaTypes_map_to_FieldType()
+	{
+		var schemaTypes =
+			((PayloadSchemaType[])Enum.GetValues(typeof(PayloadSchemaType)))
+			.Except([PayloadSchemaType.UnknownType]);
+
+		foreach (var schemaType in schemaTypes)
+		{
+			var ex = Record.Exception(() =>
+			{
+				var fieldType = QdrantClient.FieldTypeFromPayloadSchemaType(schemaType);
+			});
+
+			Assert.Null(ex);
+		}
+	}
+}


### PR DESCRIPTION
Structural test to ensure that all payload schema types are mapped to field types. Mapping is exposed at `internal`, and tests project is now also signed so that Qdrant.Client project can make internals visible to it.

This will fail if the proto introduces new mappings, so that they can be added for release.

Closes #68