### PR TITLE
Implement Dispose pattern

### DIFF
--- a/src/Qdrant.Client/Grpc/QdrantGrpcClient.cs
+++ b/src/Qdrant.Client/Grpc/QdrantGrpcClient.cs
@@ -85,10 +85,23 @@ public partial class QdrantGrpcClient : IDisposable
 	/// <inheritdoc />
 	public void Dispose()
 	{
-		if (_isDisposed)
-			return;
+		Dispose(disposing: true);
+		GC.SuppressFinalize(this);
+	}
 
-		_ownedChannel?.Dispose();
-		_isDisposed = true;
+	/// <summary>
+	/// Releases the resources used by the current instance of <see cref="QdrantGrpcClient"/>.
+	/// </summary>
+	/// <param name="disposing">Indicates whether the method is called from <see cref="Dispose()"/>
+	/// or a finalizer.</param>
+	protected virtual void Dispose(bool disposing)
+	{
+		if (!_isDisposed)
+		{
+			_isDisposed = true;
+
+			if (disposing)
+				_ownedChannel?.Dispose();
+		}
 	}
 }

--- a/src/Qdrant.Client/QdrantClient.cs
+++ b/src/Qdrant.Client/QdrantClient.cs
@@ -4631,12 +4631,23 @@ public class QdrantClient : IDisposable
 	/// <inheritdoc />
 	public void Dispose()
 	{
-		if (_isDisposed)
-			return;
+		Dispose(true);
+		GC.SuppressFinalize(this);
+	}
 
-		if (_ownsGrpcClient)
-			_grpcClient.Dispose();
+	/// <summary>
+	/// Releases the resources used by the current instance of <see cref="QdrantClient"/>.
+	/// </summary>
+	/// <param name="disposing">Indicates whether the method is called from <see cref="Dispose()"/>
+	/// or a finalizer.</param>
+	protected virtual void Dispose(bool disposing)
+	{
+		if (!_isDisposed)
+		{
+			_isDisposed = true;
 
-		_isDisposed = true;
+			if (disposing && _ownsGrpcClient)
+				_grpcClient.Dispose();
+		}
 	}
 }


### PR DESCRIPTION
This commit updates the Dispose implementations of the low level and high level client. Since both are public and not sealed, they can be inherited from, and therefore should expose an [overrideable Dispose method](https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose).