### PR TITLE
feat: Support for tracing ID headers

### DIFF
--- a/src/Qdrant.Client/Grpc/QdrantChannel.cs
+++ b/src/Qdrant.Client/Grpc/QdrantChannel.cs
@@ -33,19 +33,18 @@ public class QdrantChannel : ChannelBase, IDisposable
 		if (Disposed)
 			throw new ObjectDisposedException(nameof(QdrantChannel));
 
-		var hasApiKey = _configuration.ApiKey is not null;
-		var hasHeaders = _configuration.Headers.Count > 0;
-
-		if (!hasApiKey && !hasHeaders)
-			return _channel.CreateCallInvoker();
-
 		return _channel.Intercept(metadata =>
 		{
-			if (hasApiKey)
-				metadata.Add("api-key", _configuration.ApiKey!);
+			if (_configuration.ApiKey is not null)
+				metadata.Add("api-key", _configuration.ApiKey);
 
 			foreach (var header in _configuration.Headers)
 				metadata.Add(header.Key, header.Value);
+
+			var requestHeaders = RequestHeaders.Current;
+			if (requestHeaders is not null)
+				foreach (var header in requestHeaders)
+					metadata.Add(header.Key, header.Value);
 
 			return metadata;
 		});

--- a/src/Qdrant.Client/RequestHeaders.cs
+++ b/src/Qdrant.Client/RequestHeaders.cs
@@ -1,0 +1,42 @@
+namespace Qdrant.Client;
+
+/// <summary>
+/// Utilities for attaching per-request headers to gRPC calls.
+/// </summary>
+public static class RequestHeaders
+{
+	private static readonly AsyncLocal<IReadOnlyDictionary<string, string>?> _headers = new();
+
+	internal static IReadOnlyDictionary<string, string>? Current => _headers.Value;
+
+	/// <summary>
+	/// Sets key and value as metadata on requests made within the returned scope.
+	/// </summary>
+	public static IDisposable Use(string key, string value) =>
+		Use(new Dictionary<string, string> { [key] = value });
+
+	/// <summary>
+	/// Sets all entries of headers as metadata on requests made within the returned scope.
+	/// </summary>
+	public static IDisposable Use(IDictionary<string, string> headers)
+	{
+		var previous = _headers.Value;
+		var merged = new Dictionary<string, string>();
+		if (previous is not null)
+			foreach (var header in previous)
+				merged[header.Key] = header.Value;
+		foreach (var header in headers)
+			merged[header.Key] = header.Value;
+		_headers.Value = merged;
+		return new Scope(() => _headers.Value = previous);
+	}
+
+	private sealed class Scope : IDisposable
+	{
+		private readonly Action _restore;
+
+		internal Scope(Action restore) => _restore = restore;
+
+		public void Dispose() => _restore();
+	}
+}


### PR DESCRIPTION
Built on top of #114 

```csharp
using (RequestHeaders.Use("x-request-id", "abc-123"))
    await client.ListCollectionsAsync();
```

```csharp
using (RequestHeaders.Use("x-request-id", "abc-123")) // <- A dictionary is accepted as well.
{
    await client.UpsertAsync(...);
    await client.QueryAsync(...);
    // both carry x-request-id
}
```