### PR TITLE
refactor: Adds overloads with headers for QdrantClient and QdrantGrpcClient constructors 

### DIFF
--- a/src/Qdrant.Client/Grpc/QdrantGrpcClient.cs
+++ b/src/Qdrant.Client/Grpc/QdrantGrpcClient.cs
@@ -19,12 +19,20 @@ public partial class QdrantGrpcClient : IDisposable
 	/// <param name="host">The host to connect to.</param>
 	/// <param name="port">The port to connect to. Defaults to 6334.</param>
 	/// <param name="apiKey">The API key to use.</param>
+	public QdrantGrpcClient(string host, int port = 6334, string? apiKey = null)
+		: this(host, port, apiKey, null)
+	{
+	}
+
+	/// <summary>
+	/// Creates a new low-level gRPC client for Qdrant. Note that <see cref="QdrantClient" /> provides a higher-level,
+	/// easier to use alternative.
+	/// </summary>
+	/// <param name="host">The host to connect to.</param>
+	/// <param name="port">The port to connect to.</param>
+	/// <param name="apiKey">The API key to use.</param>
 	/// <param name="headers">Optional headers to send with every gRPC request.</param>
-	public QdrantGrpcClient(
-		string host,
-		int port = 6334,
-		string? apiKey = null,
-		IDictionary<string, string>? headers = null)
+	public QdrantGrpcClient(string host, int port, string? apiKey, IDictionary<string, string>? headers)
 		: this(new UriBuilder("http", host, port).Uri, apiKey, headers)
 	{
 	}
@@ -35,8 +43,19 @@ public partial class QdrantGrpcClient : IDisposable
 	/// </summary>
 	/// <param name="address">The address to connect to.</param>
 	/// <param name="apiKey">The API key to use.</param>
+	public QdrantGrpcClient(System.Uri address, string? apiKey = null)
+		: this(address, apiKey, null)
+	{
+	}
+
+	/// <summary>
+	/// Creates a new low-level gRPC client for Qdrant. Note that <see cref="QdrantClient" /> provides a higher-level,
+	/// easier to use alternative.
+	/// </summary>
+	/// <param name="address">The address to connect to.</param>
+	/// <param name="apiKey">The API key to use.</param>
 	/// <param name="headers">Optional headers to send with every gRPC request.</param>
-	public QdrantGrpcClient(System.Uri address, string? apiKey = null, IDictionary<string, string>? headers = null)
+	public QdrantGrpcClient(System.Uri address, string? apiKey, IDictionary<string, string>? headers)
 	{
 		var config = new ClientConfiguration { ApiKey = apiKey };
 		if (headers is not null)

--- a/src/Qdrant.Client/QdrantClient.cs
+++ b/src/Qdrant.Client/QdrantClient.cs
@@ -33,7 +33,6 @@ public class QdrantClient : IQdrantClient, IDisposable
 	/// <param name="apiKey">The API key to use.</param>
 	/// <param name="grpcTimeout">The timeout for gRPC calls to Qdrant; sets the gRPC deadline for all calls.</param>
 	/// <param name="loggerFactory">A logger factory through which to log messages.</param>
-	/// <param name="headers">Optional headers to send with every gRPC request.</param>
 	/// <remarks>
 	/// This type provides higher-level wrappers over the low-level Qdrant gRPC API. If these wrappers aren't
 	/// sufficient, <see cref="QdrantGrpcClient" /> can be used instead for low-level API access.
@@ -44,9 +43,50 @@ public class QdrantClient : IQdrantClient, IDisposable
 		bool https = false,
 		string? apiKey = null,
 		TimeSpan grpcTimeout = default,
-		ILoggerFactory? loggerFactory = null,
-		IDictionary<string, string>? headers = null)
+		ILoggerFactory? loggerFactory = null)
+		: this(host, port, https, apiKey, grpcTimeout, loggerFactory, null)
+	{
+	}
+
+	/// <summary>Instantiates a new Qdrant client.</summary>
+	/// <param name="host">The host to connect to.</param>
+	/// <param name="port">The port to connect to.</param>
+	/// <param name="https">Whether to encrypt the connection using HTTPS.</param>
+	/// <param name="apiKey">The API key to use.</param>
+	/// <param name="grpcTimeout">The timeout for gRPC calls to Qdrant; sets the gRPC deadline for all calls.</param>
+	/// <param name="loggerFactory">A logger factory through which to log messages.</param>
+	/// <param name="headers">Optional headers to send with every gRPC request.</param>
+	/// <remarks>
+	/// This type provides higher-level wrappers over the low-level Qdrant gRPC API. If these wrappers aren't
+	/// sufficient, <see cref="QdrantGrpcClient" /> can be used instead for low-level API access.
+	/// </remarks>
+	public QdrantClient(
+		string host,
+		int port,
+		bool https,
+		string? apiKey,
+		TimeSpan grpcTimeout,
+		ILoggerFactory? loggerFactory,
+		IDictionary<string, string>? headers)
 		: this(new UriBuilder(https ? "https" : "http", host, port).Uri, apiKey, grpcTimeout, loggerFactory, headers)
+	{
+	}
+
+	/// <summary>Instantiates a new Qdrant client.</summary>
+	/// <param name="address">The address to connect to.</param>
+	/// <param name="apiKey">The API key to use.</param>
+	/// <param name="grpcTimeout">The timeout for gRPC calls to Qdrant; sets the gRPC deadline for all calls.</param>
+	/// <param name="loggerFactory">A logger factory through which to log messages.</param>
+	/// <remarks>
+	/// This type provides higher-level wrappers over the low-level Qdrant gRPC API. If these wrappers aren't
+	/// sufficient, <see cref="QdrantGrpcClient" /> can be used instead for low-level API access.
+	/// </remarks>
+	public QdrantClient(
+		System.Uri address,
+		string? apiKey = null,
+		TimeSpan grpcTimeout = default,
+		ILoggerFactory? loggerFactory = null)
+		: this(address, apiKey, grpcTimeout, loggerFactory, null)
 	{
 	}
 
@@ -62,10 +102,10 @@ public class QdrantClient : IQdrantClient, IDisposable
 	/// </remarks>
 	public QdrantClient(
 		System.Uri address,
-		string? apiKey = null,
-		TimeSpan grpcTimeout = default,
-		ILoggerFactory? loggerFactory = null,
-		IDictionary<string, string>? headers = null)
+		string? apiKey,
+		TimeSpan grpcTimeout,
+		ILoggerFactory? loggerFactory,
+		IDictionary<string, string>? headers)
 		: this(new QdrantGrpcClient(address, apiKey, headers), ownsGrpcClient: true, grpcTimeout, loggerFactory)
 	{
 	}


### PR DESCRIPTION
Adding `headers` as an optional parameter to the existing constructors in #114 will be a breaking change for consumers compiled before this change (Not released yet). 

Because the default value is baked into the caller at compile time, not the method itself. So old compiled code will crash at runtime looking for a constructor that no longer exists.

Ref: https://learn.microsoft.com/en-gb/dotnet/fundamentals/apicompat/overview

<img width="697" height="126" alt="Screenshot 2026-05-07 at 7 33 12 PM" src="https://github.com/user-attachments/assets/5834c5ee-a700-409f-8cb8-30b766fab947" />

The fix is straightforward: keep the old constructors as they were, and add new ones for callers that want to pass headers.